### PR TITLE
feat: optionally allow separate table for revisioner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ london
 
 # Visual studio
 .vscode/
+
+# Goland IDE
+.idea/

--- a/main.go
+++ b/main.go
@@ -91,7 +91,10 @@ func getRunFlags(config *config.Config) []cli.Flag {
 			Name:        "use-tls",
 			Destination: &config.UseTlS,
 		},
-
+		cli.BoolFlag{
+			Name:        "use-revision-table",
+			Destination: &config.UseRevisionTable,
+		},
 		cli.StringFlag{
 			Name:        "cert-file",
 			Usage:       "path to the server TLS cert file",
@@ -120,7 +123,11 @@ func getRunFlags(config *config.Config) []cli.Flag {
 			Usage:       "azure storage table name",
 			Destination: &config.TableName,
 		},
-
+		cli.StringFlag{
+			Name:        "revision-table-name",
+			Usage:       "azure storage table name for revision",
+			Destination: &config.RevisionTableName,
+		},
 		cli.StringFlag{
 			Name:        "azure-auth-type",
 			Usage:       "supported values storage-key:either key or connection string",
@@ -133,10 +140,15 @@ func getRunFlags(config *config.Config) []cli.Flag {
 			Usage:       "azure storage account key",
 			Destination: &config.StorageKey.AccountPrimaryKey,
 		},
+		cli.StringFlag{
+			Name:        "revision-primary-account-key",
+			Usage:       "azure storage account key for revision",
+			Destination: &config.StorageKey.RevisionAccountPrimaryKey,
+		},
 
 		cli.StringFlag{
 			Name:        "connection-string",
-			Usage:       "storage connection string. mutually execlusive with account name and key",
+			Usage:       "storage connection string. mutually exclusive with account name and key",
 			Destination: &config.StorageKey.ConnectionString,
 		},
 	}

--- a/pkg/backend/store.go
+++ b/pkg/backend/store.go
@@ -58,12 +58,22 @@ type store struct {
 }
 
 func NewBackend(c *config.Config) (Backend, error) {
-	revisioner := revision.NewRevisioner(c.Runtime.StorageTable)
+	storageTable := c.Runtime.StorageTable
+	if c.UseRevisionTable {
+		storageTable = c.Runtime.RevisionStorageTable
+	}
+	revisioner := revision.NewRevisioner(storageTable)
 	s := &store{
 		config: c,
 		rev:    revisioner,
-		t:      c.Runtime.StorageTable,
-		client: c.Runtime.TableClient,
+	}
+
+	if c.UseRevisionTable {
+		s.t = c.Runtime.RevisionStorageTable
+		s.client = c.Runtime.RevisionTableClient
+	} else {
+		s.t = c.Runtime.StorageTable
+		s.client = c.Runtime.TableClient
 	}
 
 	if err := s.ensureStore(); err != nil {


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

- Adds an optional configuration to use revisioner with it's own table storage