### PR TITLE
feat: optionally allow separate table for revisioner

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     strategy:
       matrix:
         KUBERNETES_VERSION: ["v1.18.0", "v1.19.0", "v1.20.0"]
@@ -24,7 +24,7 @@ jobs:
 
       - name: Generate test vars file
         run: |
-          echo -e 'ACCOUNT_NAME '${ACCOUNT_NAME}'\nACCOUNT_KEY '${ACCOUNT_KEY}'\nTABLE_NAME '${TABLE_NAME//./}'\nLISTEN_ADDRESS '${LISTEN_ADDRESS}'\nUSE_TLS\nSERVER_CERT_FILE_PATH '${SERVER_CERT_FILE_PATH}'\nSERVER_KEY_FILE_PATH '${SERVER_KEY_FILE_PATH}'\nCLIENT_TRUSTED_CA_FILE_PATH '${CLIENT_TRUSTED_CA_FILE_PATH}'\nCLIENT_CERT_FILE_PATH '${CLIENT_CERT_FILE_PATH}'\nCLIENT_KEY_FILE_PATH '${CLIENT_KEY_FILE_PATH}'\nSERVER_TRUSTED_CA_FILE_PATH '${SERVER_TRUSTED_CA_FILE_PATH}'' | sudo tee --append hack/testing_vars  > /dev/null
+          echo -e 'ACCOUNT_NAME '${ACCOUNT_NAME}'\nACCOUNT_KEY '${ACCOUNT_KEY}'\nTABLE_NAME '${TABLE_NAME//./}'\nLISTEN_ADDRESS '${LISTEN_ADDRESS}'\nUSE_TLS\nSERVER_CERT_FILE_PATH '${SERVER_CERT_FILE_PATH}'\nSERVER_KEY_FILE_PATH '${SERVER_KEY_FILE_PATH}'\nCLIENT_TRUSTED_CA_FILE_PATH '${CLIENT_TRUSTED_CA_FILE_PATH}'\nCLIENT_CERT_FILE_PATH '${CLIENT_CERT_FILE_PATH}'\nCLIENT_KEY_FILE_PATH '${CLIENT_KEY_FILE_PATH}'\nSERVER_TRUSTED_CA_FILE_PATH '${SERVER_TRUSTED_CA_FILE_PATH}'\nREVISION_ACCOUNT_NAME '${REVISION_ACCOUNT_NAME}'\nREVISION_ACCOUNT_KEY '${REVISION_ACCOUNT_KEY}'\nREVISION_TABLE_NAME '${REVISION_TABLE_NAME//./}'' | sudo tee --append hack/testing_vars  > /dev/null
           cat hack/testing_vars
         env:
           ACCOUNT_NAME: ${{ secrets.ACCOUNT_NAME }}
@@ -37,10 +37,58 @@ jobs:
           CLIENT_CERT_FILE_PATH: ${{ github.workspace }}/hack/certs/client.crt
           CLIENT_KEY_FILE_PATH: ${{ github.workspace }}/hack/certs/client.key
           SERVER_TRUSTED_CA_FILE_PATH: ${{ github.workspace }}/hack/certs/ca.crt
+          REVISION_ACCOUNT_NAME: ${{ secrets.ACCOUNT_NAME }}
+          REVISION_ACCOUNT_KEY: ${{ secrets.ACCOUNT_KEY }}
+          REVISION_TABLE_NAME: ${{ matrix.KUBERNETES_VERSION }}rev
+          USE_REVISION_TABLE: ${{ matrix.USE_REVISION_TABLE }}
 
       - name: Get Kubernetes release
         run: |
           make get-kubernetes KUBERNETES_VERSION=${{ matrix.KUBERNETES_VERSION }}
+
+      - name: Unit test
+        run: |
+          make unit-tests
+
+      - name: Integration test
+        run: |
+          make integration-tests
+
+  revision_table_test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Generate test vars file
+        run: |
+          echo -e 'ACCOUNT_NAME '${ACCOUNT_NAME}'\nACCOUNT_KEY '${ACCOUNT_KEY}'\nTABLE_NAME '${TABLE_NAME//./}'\nLISTEN_ADDRESS '${LISTEN_ADDRESS}'\nUSE_TLS\nSERVER_CERT_FILE_PATH '${SERVER_CERT_FILE_PATH}'\nSERVER_KEY_FILE_PATH '${SERVER_KEY_FILE_PATH}'\nCLIENT_TRUSTED_CA_FILE_PATH '${CLIENT_TRUSTED_CA_FILE_PATH}'\nCLIENT_CERT_FILE_PATH '${CLIENT_CERT_FILE_PATH}'\nCLIENT_KEY_FILE_PATH '${CLIENT_KEY_FILE_PATH}'\nSERVER_TRUSTED_CA_FILE_PATH '${SERVER_TRUSTED_CA_FILE_PATH}'\nREVISION_ACCOUNT_NAME '${REVISION_ACCOUNT_NAME}'\nREVISION_ACCOUNT_KEY '${REVISION_ACCOUNT_KEY}'\nREVISION_TABLE_NAME '${REVISION_TABLE_NAME//./}'\nUSE_REVISION_TABLE' | sudo tee --append hack/testing_vars  > /dev/null
+          cat hack/testing_vars
+        env:
+          ACCOUNT_NAME: ${{ secrets.ACCOUNT_NAME }}
+          ACCOUNT_KEY: ${{ secrets.ACCOUNT_KEY }}
+          TABLE_NAME: v1120store
+          LISTEN_ADDRESS: tcp://localhost:2379
+          SERVER_CERT_FILE_PATH: ${{ github.workspace }}/hack/certs/server.crt
+          SERVER_KEY_FILE_PATH: ${{ github.workspace }}/hack/certs/server.key
+          CLIENT_TRUSTED_CA_FILE_PATH: ${{ github.workspace }}/hack/certs/ca.crt
+          CLIENT_CERT_FILE_PATH: ${{ github.workspace }}/hack/certs/client.crt
+          CLIENT_KEY_FILE_PATH: ${{ github.workspace }}/hack/certs/client.key
+          SERVER_TRUSTED_CA_FILE_PATH: ${{ github.workspace }}/hack/certs/ca.crt
+          REVISION_ACCOUNT_NAME: ${{ secrets.ACCOUNT_NAME }}
+          REVISION_ACCOUNT_KEY: ${{ secrets.ACCOUNT_KEY }}
+          REVISION_TABLE_NAME: v1120rev
+          USE_REVISION_TABLE: ${{ matrix.USE_REVISION_TABLE }}
+
+      - name: Get Kubernetes release
+        run: |
+          make get-kubernetes
 
       - name: Unit test
         run: |

--- a/hack/testing_vars_doc
+++ b/hack/testing_vars_doc
@@ -28,3 +28,12 @@ SERVER_TRUSTED_CA_FILE_PATH <path>
 # testint to focus on the problem. Normally we don't clear the table to ensure that 
 # we can select what is needed and only what is needed
 #DO_NOT_RECREATE_TABLE
+#** if this flag exists, then test will use a separate table for revision.
+# REVISION_ACCOUNT_NAME, REVISION_ACCOUNT_KEY and REVISION_TABLE_NAME are required if flag is set
+#USE_REVISION_TABLE
+#** azure storage account name for revision
+REVISION_ACCOUNT_NAME <azure storage account name for revision>
+#** azure storage account key for revision
+REVISION_ACCOUNT_KEY <for testing we use keys, we don't yet support sas or imds>
+#** azure storage account table name for revision
+REVISION_TABLE_NAME <azure storage table name for revision>

--- a/main.go
+++ b/main.go
@@ -92,6 +92,11 @@ func getRunFlags(config *config.Config) []cli.Flag {
 			Destination: &config.UseTlS,
 		},
 
+		cli.BoolFlag{
+			Name:        "use-revision-table",
+			Destination: &config.UseRevisionTable,
+		},
+
 		cli.StringFlag{
 			Name:        "cert-file",
 			Usage:       "path to the server TLS cert file",
@@ -122,6 +127,18 @@ func getRunFlags(config *config.Config) []cli.Flag {
 		},
 
 		cli.StringFlag{
+			Name:        "revision-account-name",
+			Usage:       "azure storage account name for revision",
+			Destination: &config.RevisionAccountName,
+		},
+
+		cli.StringFlag{
+			Name:        "revision-table-name",
+			Usage:       "azure storage table name for revision",
+			Destination: &config.RevisionTableName,
+		},
+
+		cli.StringFlag{
 			Name:        "azure-auth-type",
 			Usage:       "supported values storage-key:either key or connection string",
 			Value:       "storage-key",
@@ -135,8 +152,14 @@ func getRunFlags(config *config.Config) []cli.Flag {
 		},
 
 		cli.StringFlag{
+			Name:        "revision-primary-account-key",
+			Usage:       "azure storage account key for revision",
+			Destination: &config.StorageKey.RevisionAccountPrimaryKey,
+		},
+
+		cli.StringFlag{
 			Name:        "connection-string",
-			Usage:       "storage connection string. mutually execlusive with account name and key",
+			Usage:       "storage connection string. mutually exclusive with account name and key",
 			Destination: &config.StorageKey.ConnectionString,
 		},
 	}

--- a/pkg/backend/revision/revision_test.go
+++ b/pkg/backend/revision/revision_test.go
@@ -8,11 +8,14 @@ import (
 
 func TestRevisioner(t *testing.T) {
 	c := basictestutils.MakeTestConfig(t, false)
-	r := NewRevisioner(c.Runtime.StorageTable)
+	r, err := NewRevisioner(c.Runtime.RevisionStorageTable)
+	if err != nil {
+		t.Fatalf("failed to create revisioner: %v", err)
+	}
 
 	first, err := r.Increment()
 	if err != nil {
-		t.Fatalf("failed to increament:%v", err)
+		t.Fatalf("failed to increment:%v", err)
 	}
 
 	t.Logf("current rev:%v", first)
@@ -23,7 +26,7 @@ func TestRevisioner(t *testing.T) {
 		added = added + 1
 		current, err = r.Increment()
 		if err != nil {
-			t.Fatalf("failed to increament:%v", err)
+			t.Fatalf("failed to increment:%v", err)
 		}
 	}
 

--- a/pkg/backend/store.go
+++ b/pkg/backend/store.go
@@ -54,16 +54,18 @@ type store struct {
 	rev    revision.Revisioner
 	config *config.Config
 	t      *storage.Table
-	client storage.TableServiceClient
 }
 
 func NewBackend(c *config.Config) (Backend, error) {
-	revisioner := revision.NewRevisioner(c.Runtime.StorageTable)
+	revisioner, err := revision.NewRevisioner(c.Runtime.RevisionStorageTable)
+	if err != nil {
+		return nil, err
+	}
+
 	s := &store{
 		config: c,
 		rev:    revisioner,
 		t:      c.Runtime.StorageTable,
-		client: c.Runtime.TableClient,
 	}
 
 	if err := s.ensureStore(); err != nil {
@@ -90,7 +92,7 @@ func (s *store) ensureStore() error {
 			return fmt.Errorf("got status code %d:  %v", status.StatusCode, err)
 		}
 	}
-	// Test that we have write acces
+	// Test that we have write access
 	e := &storage.Entity{
 		Table: s.t,
 	}

--- a/test/utils/basic/basic.go
+++ b/test/utils/basic/basic.go
@@ -47,12 +47,17 @@ func MakeTestConfig(t testing.TB, clearTable bool) *config.Config {
 	configVals := GetTestingVars(t)
 
 	_, useTLS := configVals["USE_TLS"]
+	_, useRevisionTable := configVals["USE_REVISION_TABLE"]
 
 	c := &config.Config{}
 	c.AccountName = configVals["ACCOUNT_NAME"]
 	c.StorageKey.AccountPrimaryKey = configVals["ACCOUNT_KEY"]
 	c.StorageKey.ConnectionString = configVals["CONNECTION_STRING"]
 	c.TableName = configVals["TABLE_NAME"]
+	c.RevisionAccountName = configVals["REVISION_ACCOUNT_NAME"]
+	c.StorageKey.RevisionAccountPrimaryKey = configVals["REVISION_ACCOUNT_KEY"]
+	c.RevisionTableName = configVals["REVISION_TABLE_NAME"]
+	c.UseRevisionTable = useRevisionTable
 	// listening
 	c.ListenAddress = "tcp://0.0.0.0:2379"
 	if useTLS {


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

- Adds an optional configuration to use revisioner with it's own table storage