### PR TITLE
accelerated testing by optionally clearing the table before tests

### DIFF
--- a/pkg/backend/delete_test.go
+++ b/pkg/backend/delete_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestDelete(t *testing.T) {
-	c := basictestutils.MakeTestConfig(t)
+	c := basictestutils.MakeTestConfig(t, false)
 
 	be, err := NewBackend(c)
 	if err != nil {
@@ -67,7 +67,7 @@ func TestDelete(t *testing.T) {
 
 func TestCompactDelete(t *testing.T) {
 
-	c := basictestutils.MakeTestConfig(t)
+	c := basictestutils.MakeTestConfig(t, false)
 
 	be, err := NewBackend(c)
 	if err != nil {

--- a/pkg/backend/get_test.go
+++ b/pkg/backend/get_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestGet(t *testing.T) {
-	c := basictestutils.MakeTestConfig(t)
+	c := basictestutils.MakeTestConfig(t, false)
 
 	be, err := NewBackend(c)
 	if err != nil {

--- a/pkg/backend/insert_test.go
+++ b/pkg/backend/insert_test.go
@@ -55,7 +55,7 @@ func GetEntitiesForKeyRev(t *testing.T, c *config.Config, key string, rev int64)
 }
 
 func TestInsert(t *testing.T) {
-	c := basictestutils.MakeTestConfig(t)
+	c := basictestutils.MakeTestConfig(t, false)
 
 	be, err := NewBackend(c)
 	if err != nil {

--- a/pkg/backend/list_test.go
+++ b/pkg/backend/list_test.go
@@ -17,7 +17,7 @@ type change struct {
 }
 
 func TestListForWatch(t *testing.T) {
-	c := basictestutils.MakeTestConfig(t)
+	c := basictestutils.MakeTestConfig(t, false)
 
 	be, err := NewBackend(c)
 	if err != nil {
@@ -162,7 +162,7 @@ func TestListForWatch(t *testing.T) {
 }
 
 func TestListForPrefix(t *testing.T) {
-	c := basictestutils.MakeTestConfig(t)
+	c := basictestutils.MakeTestConfig(t, false)
 
 	be, err := NewBackend(c)
 	if err != nil {
@@ -247,7 +247,7 @@ func TestListForPrefix(t *testing.T) {
 	}
 }
 func TestListAllCurrent(t *testing.T) {
-	c := basictestutils.MakeTestConfig(t)
+	c := basictestutils.MakeTestConfig(t, true)
 
 	be, err := NewBackend(c)
 	if err != nil {

--- a/pkg/backend/revision/revision_test.go
+++ b/pkg/backend/revision/revision_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestRevisioner(t *testing.T) {
-	c := basictestutils.MakeTestConfig(t)
+	c := basictestutils.MakeTestConfig(t, false)
 	r := NewRevisioner(c.Runtime.StorageTable)
 
 	first, err := r.Increment()

--- a/pkg/backend/update_test.go
+++ b/pkg/backend/update_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestUpdate(t *testing.T) {
-	c := basictestutils.MakeTestConfig(t)
+	c := basictestutils.MakeTestConfig(t, false)
 
 	be, err := NewBackend(c)
 	if err != nil {

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -21,7 +21,7 @@ import (
 
 func creatApiServer(t *testing.T) (stopEtcdApi func(), stopApiServer func(), apiHttpServer *httptest.Server) {
 	t.Helper()
-	c := basictestutils.MakeTestConfig(t)
+	c := basictestutils.MakeTestConfig(t, false)
 	// disable mtls
 	c.UseTlS = false
 

--- a/test/integration/kv_test.go
+++ b/test/integration/kv_test.go
@@ -24,7 +24,7 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 func BenchmarkPut(b *testing.B) {
-	client, stop := getClient(b)
+	client, stop := getClient(b, false)
 	defer stop()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -32,8 +32,8 @@ func BenchmarkPut(b *testing.B) {
 	}
 }
 
-func getClient(tb testing.TB) (*clientv3.Client, func()) {
-	c := basictestutils.MakeTestConfig(tb)
+func getClient(tb testing.TB, clearTable bool) (*clientv3.Client, func()) {
+	c := basictestutils.MakeTestConfig(tb, clearTable)
 	stopfn := testutils.CreateTestApp(c, tb)
 
 	client := testutils.MakeTestEtcdClient(c, tb)
@@ -41,7 +41,7 @@ func getClient(tb testing.TB) (*clientv3.Client, func()) {
 }
 
 func TestIntegrationPut(t *testing.T) {
-	client, stop := getClient(t)
+	client, stop := getClient(t, false)
 	defer stop()
 	integrationPut(t, client)
 }
@@ -71,7 +71,7 @@ func integrationPut(t testing.TB, client *clientv3.Client) {
 }
 
 func TestIntegrationRangeGet(t *testing.T) {
-	c := basictestutils.MakeTestConfig(t)
+	c := basictestutils.MakeTestConfig(t, false)
 	stopfn := testutils.CreateTestApp(c, t)
 	defer stopfn()
 
@@ -102,7 +102,7 @@ func TestIntegrationRangeGet(t *testing.T) {
 }
 
 func TestIntegrationTxnInsert(t *testing.T) {
-	c := basictestutils.MakeTestConfig(t)
+	c := basictestutils.MakeTestConfig(t, false)
 	stopfn := testutils.CreateTestApp(c, t)
 	defer stopfn()
 
@@ -128,7 +128,7 @@ func TestIntegrationTxnInsert(t *testing.T) {
 }
 
 func TestIntegrationTxnDelete(t *testing.T) {
-	c := basictestutils.MakeTestConfig(t)
+	c := basictestutils.MakeTestConfig(t, false)
 	stopfn := testutils.CreateTestApp(c, t)
 	defer stopfn()
 
@@ -173,7 +173,7 @@ func TestIntegrationTxnDelete(t *testing.T) {
 }
 
 func BenchmarkUpdate(b *testing.B) {
-	client, stop := getClient(b)
+	client, stop := getClient(b, false)
 	defer stop()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -182,7 +182,7 @@ func BenchmarkUpdate(b *testing.B) {
 }
 
 func TestIntgrationUpdate(t *testing.T) {
-	client, stop := getClient(t)
+	client, stop := getClient(t, false)
 	defer stop()
 	intgrationUpdate(client, t)
 }
@@ -254,7 +254,7 @@ func intgrationUpdate(client *clientv3.Client, t testing.TB) {
 }
 
 func TestIntgrationCompact(t *testing.T) {
-	c := basictestutils.MakeTestConfig(t)
+	c := basictestutils.MakeTestConfig(t, false)
 	stopfn := testutils.CreateTestApp(c, t)
 	defer stopfn()
 
@@ -325,8 +325,8 @@ func TestIntgrationCompact(t *testing.T) {
 	}
 }
 
-func BenchmarkRaneList(b *testing.B) {
-	client, stop := getClient(b)
+func BenchmarkRangeList(b *testing.B) {
+	client, stop := getClient(b, false)
 	defer stop()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
@@ -334,8 +334,8 @@ func BenchmarkRaneList(b *testing.B) {
 	}
 }
 
-func TestIntgrationRaneList(t *testing.T) {
-	client, stop := getClient(t)
+func TestIntgrationRangeList(t *testing.T) {
+	client, stop := getClient(t, false)
 	defer stop()
 	intgrationRaneList(client, t)
 }

--- a/test/integration/watch_test.go
+++ b/test/integration/watch_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestIntegrationWatch(t *testing.T) {
-	c := basictestutils.MakeTestConfig(t)
+	c := basictestutils.MakeTestConfig(t, false)
 	stopfn := testutils.CreateTestApp(c, t)
 	defer stopfn()
 

--- a/test/utils/basic/basic.go
+++ b/test/utils/basic/basic.go
@@ -43,7 +43,7 @@ func GetTestingVars(t testing.TB) map[string]string {
 }
 
 // creates test config based on testing var file.
-func MakeTestConfig(t testing.TB) *config.Config {
+func MakeTestConfig(t testing.TB, clearTable bool) *config.Config {
 	configVals := GetTestingVars(t)
 
 	_, useTLS := configVals["USE_TLS"]
@@ -74,10 +74,11 @@ func MakeTestConfig(t testing.TB) *config.Config {
 	if dontRecreate {
 		return c
 	}
-	t.Logf("** CLEARING TABLE, will take a bit")
-	// TODO: Logic to drop and create table
-	ClearTable(t, c)
-
+	if clearTable {
+		t.Logf("** CLEARING TABLE, will take a bit")
+		// TODO: Logic to drop and create table
+		ClearTable(t, c)
+	}
 	return c
 }
 


### PR DESCRIPTION
**Fixes:** 
N/A
**Adds:**
N/A
**Changes:**

1. Tests utils now accepts bool to clear the table before tests. All tests - except one - do not require clearing table before running.
