### PR TITLE
Fix: Ignore old value if has been compacted

### DIFF
--- a/pkg/frontend/watch_service.go
+++ b/pkg/frontend/watch_service.go
@@ -262,6 +262,12 @@ func (fe *frontend) recordToEvent(record types.Record) (*mvccpb.Event, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// this will happen if old has been compacted out of the db
+	if oldRecord == nil {
+		return e, nil
+	}
+
 	e.PrevKv = types.RecordToKV(oldRecord)
 	return e, nil
 }


### PR DESCRIPTION
**Adds:**
N/A

**Changes:**
When generating an event for watch. If the old value has been compacted (i.e. not found) then ignore it and generate an event without the old value.

**Removes:**
N/A