### PR TITLE
ci: switch to using separate storage account

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -5,14 +5,9 @@ on:
       - "**.md"
 
 jobs:
-  test:
+  test-v1180:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    strategy:
-      matrix:
-        KUBERNETES_VERSION: ["v1.18.0", "v1.19.0", "v1.20.0"]
-      # we want the rest of matrix to run even if one jobs fails
-      fail-fast: false
     steps:
       - name: Set up Go 1.15
         uses: actions/setup-go@v2
@@ -22,14 +17,18 @@ jobs:
       - name: Checkout code into the Go module directory
         uses: actions/checkout@v2
 
+      - name: Get Kubernetes release
+        run: |
+          make get-kubernetes KUBERNETES_VERSION=v1.18.0
+
       - name: Generate test vars file
         run: |
           echo -e 'ACCOUNT_NAME '${ACCOUNT_NAME}'\nACCOUNT_KEY '${ACCOUNT_KEY}'\nTABLE_NAME '${TABLE_NAME//./}'\nLISTEN_ADDRESS '${LISTEN_ADDRESS}'\nUSE_TLS\nSERVER_CERT_FILE_PATH '${SERVER_CERT_FILE_PATH}'\nSERVER_KEY_FILE_PATH '${SERVER_KEY_FILE_PATH}'\nCLIENT_TRUSTED_CA_FILE_PATH '${CLIENT_TRUSTED_CA_FILE_PATH}'\nCLIENT_CERT_FILE_PATH '${CLIENT_CERT_FILE_PATH}'\nCLIENT_KEY_FILE_PATH '${CLIENT_KEY_FILE_PATH}'\nSERVER_TRUSTED_CA_FILE_PATH '${SERVER_TRUSTED_CA_FILE_PATH}'\nREVISION_ACCOUNT_NAME '${REVISION_ACCOUNT_NAME}'\nREVISION_ACCOUNT_KEY '${REVISION_ACCOUNT_KEY}'\nREVISION_TABLE_NAME '${REVISION_TABLE_NAME//./}'' | sudo tee --append hack/testing_vars  > /dev/null
           cat hack/testing_vars
         env:
-          ACCOUNT_NAME: ${{ secrets.ACCOUNT_NAME }}
-          ACCOUNT_KEY: ${{ secrets.ACCOUNT_KEY }}
-          TABLE_NAME: ${{ matrix.KUBERNETES_VERSION }}
+          ACCOUNT_NAME: ${{ secrets.ACCOUNT_NAME_1 }}
+          ACCOUNT_KEY: ${{ secrets.ACCOUNT_KEY_1 }}
+          TABLE_NAME: v1180
           LISTEN_ADDRESS: tcp://localhost:2379
           SERVER_CERT_FILE_PATH: ${{ github.workspace }}/hack/certs/server.crt
           SERVER_KEY_FILE_PATH: ${{ github.workspace }}/hack/certs/server.key
@@ -37,14 +36,86 @@ jobs:
           CLIENT_CERT_FILE_PATH: ${{ github.workspace }}/hack/certs/client.crt
           CLIENT_KEY_FILE_PATH: ${{ github.workspace }}/hack/certs/client.key
           SERVER_TRUSTED_CA_FILE_PATH: ${{ github.workspace }}/hack/certs/ca.crt
-          REVISION_ACCOUNT_NAME: ${{ secrets.ACCOUNT_NAME }}
-          REVISION_ACCOUNT_KEY: ${{ secrets.ACCOUNT_KEY }}
-          REVISION_TABLE_NAME: ${{ matrix.KUBERNETES_VERSION }}rev
-          USE_REVISION_TABLE: ${{ matrix.USE_REVISION_TABLE }}
+
+      - name: Unit test
+        run: |
+          make unit-tests
+
+      - name: Integration test
+        run: |
+          make integration-tests
+
+  test-v1190:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v2
 
       - name: Get Kubernetes release
         run: |
-          make get-kubernetes KUBERNETES_VERSION=${{ matrix.KUBERNETES_VERSION }}
+          make get-kubernetes KUBERNETES_VERSION=v1.19.0
+
+      - name: Generate test vars file
+        run: |
+          echo -e 'ACCOUNT_NAME '${ACCOUNT_NAME}'\nACCOUNT_KEY '${ACCOUNT_KEY}'\nTABLE_NAME '${TABLE_NAME//./}'\nLISTEN_ADDRESS '${LISTEN_ADDRESS}'\nUSE_TLS\nSERVER_CERT_FILE_PATH '${SERVER_CERT_FILE_PATH}'\nSERVER_KEY_FILE_PATH '${SERVER_KEY_FILE_PATH}'\nCLIENT_TRUSTED_CA_FILE_PATH '${CLIENT_TRUSTED_CA_FILE_PATH}'\nCLIENT_CERT_FILE_PATH '${CLIENT_CERT_FILE_PATH}'\nCLIENT_KEY_FILE_PATH '${CLIENT_KEY_FILE_PATH}'\nSERVER_TRUSTED_CA_FILE_PATH '${SERVER_TRUSTED_CA_FILE_PATH}'\nREVISION_ACCOUNT_NAME '${REVISION_ACCOUNT_NAME}'\nREVISION_ACCOUNT_KEY '${REVISION_ACCOUNT_KEY}'\nREVISION_TABLE_NAME '${REVISION_TABLE_NAME//./}'' | sudo tee --append hack/testing_vars  > /dev/null
+          cat hack/testing_vars
+        env:
+          ACCOUNT_NAME: ${{ secrets.ACCOUNT_NAME_2 }}
+          ACCOUNT_KEY: ${{ secrets.ACCOUNT_KEY_2 }}
+          TABLE_NAME: v1190
+          LISTEN_ADDRESS: tcp://localhost:2379
+          SERVER_CERT_FILE_PATH: ${{ github.workspace }}/hack/certs/server.crt
+          SERVER_KEY_FILE_PATH: ${{ github.workspace }}/hack/certs/server.key
+          CLIENT_TRUSTED_CA_FILE_PATH: ${{ github.workspace }}/hack/certs/ca.crt
+          CLIENT_CERT_FILE_PATH: ${{ github.workspace }}/hack/certs/client.crt
+          CLIENT_KEY_FILE_PATH: ${{ github.workspace }}/hack/certs/client.key
+          SERVER_TRUSTED_CA_FILE_PATH: ${{ github.workspace }}/hack/certs/ca.crt
+
+      - name: Unit test
+        run: |
+          make unit-tests
+
+      - name: Integration test
+        run: |
+          make integration-tests
+
+  test-v1200:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Set up Go 1.15
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+
+      - name: Checkout code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Get Kubernetes release
+        run: |
+          make get-kubernetes KUBERNETES_VERSION=v1.20.0
+
+      - name: Generate test vars file
+        run: |
+          echo -e 'ACCOUNT_NAME '${ACCOUNT_NAME}'\nACCOUNT_KEY '${ACCOUNT_KEY}'\nTABLE_NAME '${TABLE_NAME//./}'\nLISTEN_ADDRESS '${LISTEN_ADDRESS}'\nUSE_TLS\nSERVER_CERT_FILE_PATH '${SERVER_CERT_FILE_PATH}'\nSERVER_KEY_FILE_PATH '${SERVER_KEY_FILE_PATH}'\nCLIENT_TRUSTED_CA_FILE_PATH '${CLIENT_TRUSTED_CA_FILE_PATH}'\nCLIENT_CERT_FILE_PATH '${CLIENT_CERT_FILE_PATH}'\nCLIENT_KEY_FILE_PATH '${CLIENT_KEY_FILE_PATH}'\nSERVER_TRUSTED_CA_FILE_PATH '${SERVER_TRUSTED_CA_FILE_PATH}'\nREVISION_ACCOUNT_NAME '${REVISION_ACCOUNT_NAME}'\nREVISION_ACCOUNT_KEY '${REVISION_ACCOUNT_KEY}'\nREVISION_TABLE_NAME '${REVISION_TABLE_NAME//./}'' | sudo tee --append hack/testing_vars  > /dev/null
+          cat hack/testing_vars
+        env:
+          ACCOUNT_NAME: ${{ secrets.ACCOUNT_NAME_3 }}
+          ACCOUNT_KEY: ${{ secrets.ACCOUNT_KEY_3 }}
+          TABLE_NAME: v1200
+          LISTEN_ADDRESS: tcp://localhost:2379
+          SERVER_CERT_FILE_PATH: ${{ github.workspace }}/hack/certs/server.crt
+          SERVER_KEY_FILE_PATH: ${{ github.workspace }}/hack/certs/server.key
+          CLIENT_TRUSTED_CA_FILE_PATH: ${{ github.workspace }}/hack/certs/ca.crt
+          CLIENT_CERT_FILE_PATH: ${{ github.workspace }}/hack/certs/client.crt
+          CLIENT_KEY_FILE_PATH: ${{ github.workspace }}/hack/certs/client.key
+          SERVER_TRUSTED_CA_FILE_PATH: ${{ github.workspace }}/hack/certs/ca.crt
 
       - name: Unit test
         run: |
@@ -84,7 +155,6 @@ jobs:
           REVISION_ACCOUNT_NAME: ${{ secrets.ACCOUNT_NAME }}
           REVISION_ACCOUNT_KEY: ${{ secrets.ACCOUNT_KEY }}
           REVISION_TABLE_NAME: v1120rev
-          USE_REVISION_TABLE: ${{ matrix.USE_REVISION_TABLE }}
 
       - name: Get Kubernetes release
         run: |


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

- Switches to using different accounts for the test runs
- Removing the matrix and making them individual jobs now. We can refactor later to see if there is a way to use matix and use dynamic secrets name. 