### PR TITLE
minimize the cache induced conflicts by updating cache on failed txns

### DIFF
--- a/pkg/frontend/listmanager.go
+++ b/pkg/frontend/listmanager.go
@@ -524,6 +524,10 @@ func (l *list) deleted(r types.Record) {
 	l.items.Delete(string(r.Key()))
 }
 
+func (l *list) deletedByKey(key string) {
+	l.items.Delete(key)
+}
+
 func (lm *listManager) notifyCompact(compactRev int64) {
 	// hmm assuming that we are on 64b, no torn reads
 	if lm.revLowWatermark < compactRev {
@@ -546,6 +550,14 @@ func (lm *listManager) notifyDeleted(r types.Record) {
 	// we ignore error here because we don't reload
 	l, _ := lm.getList(prefix, false)
 	l.deleted(r)
+}
+
+// used by front end to notify listManager of a deleted record by "key"
+func (lm *listManager) notifyDeletedKey(key string) {
+	prefix := prefixFromKey(key)
+	// we ignore error here because we don't reload
+	l, _ := lm.getList(prefix, false)
+	l.deletedByKey(key)
 }
 
 // used by front end to notify listManager of an updated record


### PR DESCRIPTION
Adds:
N/A

Changes:
in a multi `london` deployments where caches can be at different levels. an api-server may fail to perform a txn (update, delete, etc) and it will keep doing get->txn loop which can cause a large # of failed transactions against storage that can be avoided. This PR refreshes the caches using the failed statuses (e.g. NotFound result into deletion from ListManager without having to wait for next run cycle).

Deletes:
N/A