### PR TITLE
fix: configure revision table when connection string used

### DIFF
--- a/main.go
+++ b/main.go
@@ -162,5 +162,11 @@ func getRunFlags(config *config.Config) []cli.Flag {
 			Usage:       "storage connection string. mutually exclusive with account name and key",
 			Destination: &config.StorageKey.ConnectionString,
 		},
+
+		cli.StringFlag{
+			Name:        "revision-connection-string",
+			Usage:       "storage connection string for revision. mutually exclusive with account name and key",
+			Destination: &config.StorageKey.RevisionConnectionString,
+		},
 	}
 }


### PR DESCRIPTION
Signed-off-by: Anish Ramasekar <anish.ramasekar@gmail.com>

- Adds a new flag to configure connection string for revision table
- Fix the revision table storage client initialization when using connection string