### PR TITLE
compact in memory events even if DB was not compacted

### DIFF
--- a/main.go
+++ b/main.go
@@ -86,6 +86,11 @@ func getRunFlags(config *config.Config) []cli.Flag {
 			Value:       "tcp://0.0.0.0:2379",
 			Destination: &config.ListenAddress,
 		},
+		cli.IntFlag{
+			Name: "max-event-count",
+			Value: 10000, // Should be increased for large clusters
+			Destination: &config.MaxEventCount,
+		}
 
 		cli.BoolFlag{
 			Name:        "use-tls",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -73,6 +73,9 @@ type Config struct {
 
 	// TODO MSI etc
 
+	// max in memory cached events
+	MaxEventCount int
+
 	Runtime Runtime
 }
 

--- a/test/utils/basic/basic.go
+++ b/test/utils/basic/basic.go
@@ -51,6 +51,7 @@ func MakeTestConfig(t testing.TB, clearTable bool) *config.Config {
 	_, useRevisionTable := configVals["USE_REVISION_TABLE"]
 
 	c := &config.Config{}
+	c.MaxEventCount = 10000
 	c.AccountName = configVals["ACCOUNT_NAME"]
 	c.StorageKey.AccountPrimaryKey = configVals["ACCOUNT_KEY"]
 	c.StorageKey.ConnectionString = configVals["CONNECTION_STRING"]


### PR DESCRIPTION
Compacts events even if DB is not compacted. There is a new configuration flag added (defaulted to 10000 event). What will happen:
1. If the DB is compacted (and compact removes all events except the 10k), then we will use the DB compacted rev.
2. If the DB is not compacted then we always keep the last Config.MaxEventCount.
3. When we initially startup we always load MaxOf(last Config.MaxEventCount)